### PR TITLE
Add ECAD Forge README link

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ The directory structure is as follows:
           Project Outputs/       - BOM, rule check reports, Gerbers, pick & place files, PDFs
           Schematics/            - Schematic diagrams
 
+## Hardware Viewer
+
+The PCB layout can be inspected in a browser with [ECAD Forge](https://ecadforge.app/?url=https%3A%2F%2Fgithub.com%2Fmyriadrf%2FLimeSDR-Mini%2Ftree%2Fmaster%2Fhardware%2F1v3&document=PCB%2FLimeSDR_Mini_1v3_Rounded.PcbDoc), without installing Altium.
+
 ## Licensing
 
 The hardware designs are licensed under a Creative Commons Attribution 3.0 Unported licence.

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The directory structure is as follows:
 
 ## Hardware Viewer
 
-The PCB layout can be inspected in a browser with [ECAD Forge](https://ecadforge.app/?url=https%3A%2F%2Fgithub.com%2Fmyriadrf%2FLimeSDR-Mini%2Ftree%2Fmaster%2Fhardware%2F1v3&document=PCB%2FLimeSDR_Mini_1v3_Rounded.PcbDoc), without installing Altium.
+The PCB layout can be inspected in a browser with [ECAD Forge](https://ecadforge.app/?url=https%3A%2F%2Fgithub.com%2Fmyriadrf%2FLimeSDR-Mini%2Ftree%2Fmaster%2Fhardware%2F1v3), without installing Altium.
 
 ## Licensing
 


### PR DESCRIPTION
## Summary

This adds a README link to open the LimeSDR-Mini hardware/1v3 design files in ECAD Forge, an online ECAD viewer I built with privacy in mind.

## Background

I used the LimeSDR Altium design files while testing ECAD Forge because they exercise a lot of Altium features. Since the files were helpful as a real-world test case, I thought it might also be useful for others if the README included a link to inspect the older LimeSDR-Mini hardware in a browser without installing Altium.

This matches the Mini v2 README update; I will do the same for the new Micro as well.